### PR TITLE
HCK-4675: resolve field in schema properly

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -623,7 +623,7 @@ const getStatementValue = (field, fieldData) => {
 		if (!field) {
 			return fieldStatementValue;
 		}
-    if ([field.type, field.childType].some(type => type === 'temporal')) {
+    if ([field.type, field.childType].includes('temporal')) {
         return getTemporalFieldFunctionStatement(field.mode, fieldStatementValue);
     }
     return fieldStatementValue;


### PR DESCRIPTION
* Pattern fields are placed within its own `patternProperties` key in schema after preparing the data in studio, however in plugin's script that key were ignored while resolving the actual `field` info.