### PR TITLE
HCK-8904: Preserve parentCollection on cleanDependencies

### DIFF
--- a/properties_pane/entity_level/entityLevelConfig.json
+++ b/properties_pane/entity_level/entityLevelConfig.json
@@ -155,6 +155,7 @@ making sure that you maintain a proper JSON format.
 			},
 			{
 				"propertyKeyword": "parentCollection",
+				"preserveOnCleanDependencies": true,
 				"disabledOnCondition": {
 					"type": "not",
 					"values": {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8904" title="HCK-8904" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-8904</a>  Preserve parentCollection on cleanDependencies
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Before the fix, the parentCollection was removed from the model during the dependency check, causing the reference to the parent to become invalid.