### PR TITLE
HCK-14240: add relationship direction mapping for new Polyglot conceptual relationships

### DIFF
--- a/polyglot/convertAdapter.json
+++ b/polyglot/convertAdapter.json
@@ -41,16 +41,6 @@
  */
 {
 	"modify": {
-		"field": [
-			{
-				"from": {
-					"compositeUniqueKey": true
-				},
-				"to": {
-					"unique": true
-				}
-			}
-		],
-		"relationship": [["mapEdgeRelationshipDirectionForPolyglotDerive"]]
+		"relationship": [["mapEdgeRelationshipDirectionForPolyglotConvert"]]
 	}
 }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-14240" title="HCK-14240" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-14240</a>  Graph-target: derive: Polyglot "Both direction" value should be derived as "implicitly bi-directional"
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

The new Polyglot conceptual relationships introduce a `direction` property.
For Polyglot derivations, `direction: bidirectional` is mapped to a bidirectional edge (`bidirectional: true`).
During conversion to Polyglot, bidirectional relationships are mapped to `direction: bidirectional`.